### PR TITLE
nicer import UX 

### DIFF
--- a/core/shared/src/main/scala-2/pink/cozydev/snakecase/literals.scala
+++ b/core/shared/src/main/scala-2/pink/cozydev/snakecase/literals.scala
@@ -19,10 +19,6 @@ package pink.cozydev.snakecase
 import org.typelevel.literally.Literally
 
 object literals {
-  implicit class snake(val sc: StringContext) extends AnyVal {
-    def snake(args: Any*): SnakeCase = macro SnakeCaseLiteral.make
-  }
-
   object SnakeCaseLiteral extends Literally[SnakeCase] {
     def validate(c: Context)(s: String) = {
       import c.universe._

--- a/core/shared/src/main/scala-2/pink/cozydev/snakecase/package.scala
+++ b/core/shared/src/main/scala-2/pink/cozydev/snakecase/package.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2023 CozyDev
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package pink.cozydev
 
 import pink.cozydev.snakecase.literals._

--- a/core/shared/src/main/scala-2/pink/cozydev/snakecase/package.scala
+++ b/core/shared/src/main/scala-2/pink/cozydev/snakecase/package.scala
@@ -1,0 +1,9 @@
+package pink.cozydev
+
+import pink.cozydev.snakecase.literals._
+
+package object snakecase {
+  implicit class snake(val sc: StringContext) extends AnyVal {
+    def snake(args: Any*): SnakeCase = macro SnakeCaseLiteral.make
+  }
+}

--- a/core/shared/src/main/scala-3/pink/cozydev/snakecase/literals.scala
+++ b/core/shared/src/main/scala-3/pink/cozydev/snakecase/literals.scala
@@ -19,11 +19,6 @@ package pink.cozydev.snakecase
 import org.typelevel.literally.Literally
 
 object literals {
-  extension (inline ctx: StringContext) {
-    inline def snake(inline args: Any*): SnakeCase =
-      ${ SnakeCaseLiteral('ctx, 'args) }
-  }
-
   object SnakeCaseLiteral extends Literally[SnakeCase] {
     def validate(s: String)(using Quotes) =
       SnakeCase.snake.parseAll(s) match {

--- a/core/shared/src/main/scala-3/pink/cozydev/snakecase/package.scala
+++ b/core/shared/src/main/scala-3/pink/cozydev/snakecase/package.scala
@@ -16,4 +16,11 @@
 
 package pink.cozydev
 
-package object snakecase
+import pink.cozydev.snakecase.literals._
+
+package object snakecase {
+  extension (inline ctx: StringContext) {
+    inline def snake(inline args: Any*): SnakeCase =
+      ${ SnakeCaseLiteral('ctx, 'args) }
+  }
+}

--- a/core/shared/src/main/scala-3/pink/cozydev/snakecase/package.scala
+++ b/core/shared/src/main/scala-3/pink/cozydev/snakecase/package.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2023 CozyDev
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package pink.cozydev
 
 package object snakecase

--- a/core/shared/src/main/scala-3/pink/cozydev/snakecase/package.scala
+++ b/core/shared/src/main/scala-3/pink/cozydev/snakecase/package.scala
@@ -1,0 +1,3 @@
+package pink.cozydev
+
+package object snakecase

--- a/core/shared/src/test/scala/pink/cozydev/snakecase/SnakeCaseSuite.scala
+++ b/core/shared/src/test/scala/pink/cozydev/snakecase/SnakeCaseSuite.scala
@@ -52,7 +52,7 @@ class SnakeCaseSuite extends munit.FunSuite {
 }
 
 class LiteralSnakeCaseSuite extends munit.FunSuite {
-  import pink.cozydev.snakecase.literals._
+  import pink.cozydev.snakecase._
 
   test("snake_case string construction") {
     assertEquals(snake"sam_is_cool", SnakeCase.unsafeFromString("sam_is_cool"))


### PR DESCRIPTION
unrelated TODO but could be done in this PR anyway
- the `toString` override?
  - currently both `toString` and `toString()` are shown in editor completion, which seems weird and/or confusing 