### PR TITLE
Docs update - supported scala binary version

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -9,7 +9,7 @@ For the purposes of this library, a valid `snake_case` string:
 
 ### Usage
 
-This library is currently available for Scala binary versions 2.13 and 3.2.
+This library is currently available for Scala binary versions 2.13 and 3.
 
 To use the latest version, include the following in your `build.sbt`:
 


### PR DESCRIPTION
The docs were specifying that snakecase was published for Scala 3.2, but I think it's just relevant that it's published for binary version 3.x. 