### PR TITLE
Fix link to literally project

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -65,7 +65,7 @@ lazy val docs = project
             ThemeNavigationSection(
               "Related Projects",
               TextLink
-                .external("https:/github.com/typelevel/literally", "literally")
+                .external("https://github.com/typelevel/literally", "literally")
             )
           )
         )


### PR DESCRIPTION
The current link URL is malformed so we get a weird (and broken) relative link

<img width="457" height="415" alt="Screenshot 2025-09-07 at 9 38 12 AM" src="https://github.com/user-attachments/assets/1942c53a-f6ef-42ab-9ff3-9e177e8cfbbd" />
